### PR TITLE
working implementation of Parameter updates 

### DIFF
--- a/Logic/vtkSlicerROS2Logic.h
+++ b/Logic/vtkSlicerROS2Logic.h
@@ -36,6 +36,7 @@ namespace rclcpp {
 class vtkMRMLTransformNode;
 class vtkMRMLROS2SubscriberNode;
 class vtkMRMLROS2PublisherNode;
+class vtkMRMLROS2ParameterNode;
 
 // Slicer includes
 #include <vtkSlicerModuleLogic.h>
@@ -97,9 +98,12 @@ public:
     new publisher was not created. */
   vtkMRMLROS2PublisherNode * CreateAndAddPublisher(const char * className, const std::string & topic);
 
+  vtkMRMLROS2ParameterNode * CreateAndAddParameter(const char * className, const std::string & topic);
+
   void AddROS2Node(void);
   void AddSomePublishers(void);
   void AddSomeSubscribers(void);
+  void AddSomeParameters(void);
 
   // std::vector<vtkSmartPointer<vtkMRMLROS2SubscriberNode>> mSubs; // This is a list of the subscribers to update the widget
   vtkSmartPointer<vtkMRMLROS2NODENode> mROS2Node; // proper MRML node // Moved to public which might be wrong!!

--- a/MRML/vtkMRMLROS2NODENode.cxx
+++ b/MRML/vtkMRMLROS2NODENode.cxx
@@ -3,6 +3,7 @@
 #include "vtkCommand.h"
 #include <vtkMRMLROS2SubscriberNode.h>
 #include <vtkMRMLROS2PublisherNode.h> 
+#include <vtkMRMLROS2ParameterNode.h> 
 
 vtkStandardNewMacro(vtkMRMLROS2NODENode);
 
@@ -89,6 +90,21 @@ vtkMRMLROS2PublisherNode* vtkMRMLROS2NODENode::GetPublisherNodeByTopic(const std
   return nullptr; // otherwise return a null ptr
 }
 
+vtkMRMLROS2ParameterNode* vtkMRMLROS2NODENode::GetParameterNodeByTopic(const std::string & topic)
+{
+  int parameterRefs = this->GetNumberOfNodeReferences("parameter");
+  for (int j = 0; j < parameterRefs; j ++) {
+    vtkMRMLROS2ParameterNode * node = vtkMRMLROS2ParameterNode::SafeDownCast(this->GetNthNodeReference("parameter", j));
+    if (!node) {
+      vtkWarningMacro(<< "Node referenced by role 'parameter' is not a parameter");
+    }
+    std::string topicName = node->GetTopic(); 
+    if (topicName == topic) { // check if an existing nodes name matches the topic provided
+      return node; // if so return the node
+    }
+  }
+  return nullptr; // otherwise return a null ptr
+}
 
 void vtkMRMLROS2NODENode::Spin(void)
 {

--- a/MRML/vtkMRMLROS2NODENode.h
+++ b/MRML/vtkMRMLROS2NODENode.h
@@ -10,12 +10,14 @@
 class vtkMRMLROS2NodeInternals;
 class vtkMRMLROS2SubscriberNode;
 class vtkMRMLROS2PublisherNode;
+class vtkMRMLROS2ParameterNode;
 
 class VTK_SLICER_ROS2_MODULE_MRML_EXPORT vtkMRMLROS2NODENode: public vtkMRMLNode
 {
 
   template <typename _ros_type, typename _slicer_type> friend class vtkMRMLROS2SubscriberTemplatedInternals;
   template <typename _slicer_type, typename _ros_type> friend class vtkMRMLROS2PublisherTemplatedInternals;
+  template <typename _slicer_type, typename _ros_type> friend class vtkMRMLROS2ParameterTemplatedInternals;
 
  public:
   typedef vtkMRMLROS2NODENode SelfType;
@@ -32,6 +34,7 @@ class VTK_SLICER_ROS2_MODULE_MRML_EXPORT vtkMRMLROS2NODENode: public vtkMRMLNode
   void Spin(void);
   vtkMRMLROS2SubscriberNode* GetSubscriberNodeByTopic(const std::string & topic);
   vtkMRMLROS2PublisherNode* GetPublisherNodeByTopic(const std::string & topic);
+  vtkMRMLROS2ParameterNode* GetParameterNodeByTopic(const std::string & topic);
 
   // Save and load
   virtual void ReadXMLAttributes(const char** atts) override;

--- a/MRML/vtkMRMLROS2ParameterInternals.h
+++ b/MRML/vtkMRMLROS2ParameterInternals.h
@@ -1,0 +1,142 @@
+#ifndef __vtkMRMLROS2ParameterInternals_h
+#define __vtkMRMLROS2ParameterInternals_h
+
+// ROS2 includes
+#include <rclcpp/rclcpp.hpp>
+
+#include <vtkMRMLScene.h>
+#include <vtkMRMLROS2NODENode.h>
+#include <vtkMRMLROS2NodeInternals.h>
+
+class vtkMRMLROS2ParameterInternals
+{
+public:
+  vtkMRMLROS2ParameterInternals(vtkMRMLROS2ParameterNode * mrmlNode):
+    mMRMLNode(mrmlNode)
+  {}
+  virtual ~vtkMRMLROS2ParameterInternals() = default;
+
+  virtual bool AddToROS2Node(vtkMRMLScene * scene, const char * nodeId,
+			     const std::string & topic, std::string & errorMessage) = 0;
+  virtual bool IsAddedToROS2Node(void) const = 0;
+  virtual const char * GetROSType(void) const = 0;
+  virtual const char * GetSlicerType(void) const = 0;
+  virtual std::string GetLastMessageYAML(void) const = 0;
+
+protected:
+  vtkMRMLROS2ParameterNode * mMRMLNode;
+};
+
+
+template <typename _ros_type, typename _slicer_type>
+class vtkMRMLROS2ParameterTemplatedInternals: public vtkMRMLROS2ParameterInternals
+{
+public:
+  typedef vtkMRMLROS2ParameterTemplatedInternals<_ros_type, _slicer_type> SelfType;
+
+  vtkMRMLROS2ParameterTemplatedInternals(vtkMRMLROS2ParameterNode *  mrmlNode):
+    vtkMRMLROS2ParameterInternals(mrmlNode)
+  {}
+
+protected:
+  _ros_type mLastMessageROS;
+  std::shared_ptr<rclcpp::Subscription<_ros_type>> mSubscription = nullptr;
+  std::shared_ptr<rclcpp::ParameterEventHandler> param_subscriber_ = nullptr;
+  std::shared_ptr<rclcpp::ParameterEventCallbackHandle> cb_handle;
+
+  /**
+   * This is the ROS callback for the subscription.  This methods
+   * saves the ROS message as-is and set the modified flag for the
+   * MRML node
+   */
+  void ParameterCallback(const _ros_type & message) {
+    // \todo is there a timestamp in MRML nodes we can update from the ROS message?
+    mLastMessageROS = message;
+    mMRMLNode->mNumberOfMessages++;
+    mMRMLNode->Modified();
+  }
+
+  /**
+   * Add the subscriber to the ROS2 node.  This methods searched the
+   * vtkMRMLROS2NODENode by Id to locate the rclcpp::node
+   */
+  bool AddToROS2Node(vtkMRMLScene * scene, const char * nodeId,
+		     const std::string & topic, std::string & errorMessage) {
+
+    vtkMRMLNode * rosNodeBasePtr = scene->GetNodeByID(nodeId);
+
+    if (!rosNodeBasePtr) {
+      errorMessage = "unable to locate node";
+      return false;
+    }
+
+    vtkMRMLROS2NODENode * rosNodePtr = dynamic_cast<vtkMRMLROS2NODENode *>(rosNodeBasePtr);
+
+    if (!rosNodePtr) {
+      errorMessage = std::string(rosNodeBasePtr->GetName()) + " doesn't seem to be a vtkMRMLROS2NODENode";
+      return false;
+    }
+
+    std::shared_ptr<rclcpp::Node> nodePointer = rosNodePtr->mInternals->mNodePointer;
+
+    param_subscriber_ = std::make_shared<rclcpp::ParameterEventHandler>(nodePointer);
+
+    std::cerr << "Added param node \n" << std::endl;
+
+    auto cb = [nodePointer](const rcl_interfaces::msg::ParameterEvent &event)
+    {
+        // Obtain list of parameters that changed
+        auto params = rclcpp::ParameterEventHandler::get_parameters_from_event(event);
+
+        // Iterate through every parameter in the list
+        for (auto &p : params)
+        {
+            // Create a string message from the info received.
+            std::string msgString = "Param Name :" + p.get_name() + " | Param Type : " + p.get_type_name() + " | Param Value : " + p.value_to_string();
+            std::cerr << "Received an update to a parameter"  << std::endl;
+            std::cerr << msgString << "\n" <<std::endl;
+
+        }
+    };
+
+    cb_handle = param_subscriber_->add_parameter_event_callback(cb);
+
+    // mSubscription
+    //   = nodePointer->create_subscription<_ros_type>(topic, 100,
+		// 				    std::bind(&SelfType::ParameterCallback, this, std::placeholders::_1));
+
+    rosNodePtr->SetNthNodeReferenceID("parameter",
+				      rosNodePtr->GetNumberOfNodeReferences("parameter"),
+				      mMRMLNode->GetID());
+              
+    mMRMLNode->SetNodeReferenceID("node", nodeId);
+
+    return true;
+
+  }
+
+  bool IsAddedToROS2Node(void) const override
+  {
+    return (mSubscription != nullptr);
+  }
+
+  const char * GetROSType(void) const override
+  {
+    return rosidl_generator_traits::name<_ros_type>();
+  }
+
+  const char * GetSlicerType(void) const override
+  {
+    return typeid(_slicer_type).name();
+  }
+
+  std::string GetLastMessageYAML(void) const override
+  {
+    std::stringstream out;
+    rosidl_generator_traits::to_yaml(mLastMessageROS, out);
+    return out.str();
+  }
+};
+
+#endif
+// __vtkMRMLROS2ParameterInternals_h

--- a/MRML/vtkMRMLROS2ParameterNativeInternals.h
+++ b/MRML/vtkMRMLROS2ParameterNativeInternals.h
@@ -1,0 +1,32 @@
+#ifndef __vtkMRMLROS2ParameterNativeInternals_h
+#define __vtkMRMLROS2ParameterNativeInternals_h
+
+#include <vtkMRMLROS2ParameterInternals.h>
+
+template <typename _ros_type, typename _slicer_type>
+class vtkMRMLROS2ParameterNativeInternals:
+  public vtkMRMLROS2ParameterTemplatedInternals<_ros_type, _slicer_type>
+{
+public:
+  typedef vtkMRMLROS2ParameterTemplatedInternals<_ros_type, _slicer_type> BaseType;
+
+  vtkMRMLROS2ParameterNativeInternals(vtkMRMLROS2ParameterNode * mrmlNode):
+    BaseType(mrmlNode)
+  {}
+
+  _slicer_type mLastMessageSlicer;
+
+  void GetLastMessage(_slicer_type & result)
+  {
+    // todo maybe add some check that we actually received a message?
+    vtkROS2ToSlicer(this->mLastMessageROS, result);
+  }
+
+  vtkVariant GetLastMessageVariant(void)
+  {
+    GetLastMessage(mLastMessageSlicer);
+    return vtkVariant(mLastMessageSlicer);
+  }
+};
+
+#endif // __vtkMRMLROS2ParameterNativeInternals_h

--- a/MRML/vtkMRMLROS2ParameterNativeMacros.h
+++ b/MRML/vtkMRMLROS2ParameterNativeMacros.h
@@ -1,0 +1,61 @@
+#ifndef __vtkMRMLROS2ParameterNativeMacros_h
+#define __vtkMRMLROS2ParameterNativeMacros_h
+
+#define VTK_MRML_ROS_PARAMETER_NATIVE_H(slicer_type, name)		\
+  class VTK_SLICER_ROS2_MODULE_MRML_EXPORT vtkMRMLROS2Parameter##name##Node: \
+    public vtkMRMLROS2ParameterNode					\
+  {									\
+  public:								\
+    typedef vtkMRMLROS2Parameter##name##Node SelfType;			\
+    vtkTypeMacro(vtkMRMLROS2Parameter##name##Node, vtkMRMLROS2ParameterNode);	\
+									\
+    static SelfType * New(void);					\
+    vtkMRMLNode * CreateNodeInstance(void) override;			\
+    const char * GetNodeTagName(void) override;				\
+    void GetLastMessage(slicer_type & message) const;			\
+    vtkVariant GetLastMessageVariant(void) override;			\
+									\
+  protected:								\
+    vtkMRMLROS2Parameter##name##Node();				\
+    ~vtkMRMLROS2Parameter##name##Node();				\
+  }
+
+
+#define VTK_MRML_ROS_PARAMETER_NATIVE_CXX(ros_type, slicer_type, name) \
+									\
+  vtkStandardNewMacro(vtkMRMLROS2Parameter##name##Node);		\
+									\
+  typedef vtkMRMLROS2ParameterNativeInternals<ros_type, slicer_type>	\
+  vtkMRMLROS2Parameter##name##Internals;				\
+  									\
+ vtkMRMLROS2Parameter##name##Node::vtkMRMLROS2Parameter##name##Node()	\
+ {									\
+   mInternals = new vtkMRMLROS2Parameter##name##Internals(this);	\
+ }									\
+									\
+ vtkMRMLROS2Parameter##name##Node::~vtkMRMLROS2Parameter##name##Node() \
+ {									\
+   delete mInternals;							\
+ }									\
+									\
+ vtkMRMLNode * vtkMRMLROS2Parameter##name##Node::CreateNodeInstance(void) \
+ {									\
+   return SelfType::New();						\
+ }									\
+									\
+ const char * vtkMRMLROS2Parameter##name##Node::GetNodeTagName(void)	\
+ {									\
+   return "ROS2Parameter"#name;					\
+ }									\
+									\
+ void vtkMRMLROS2Parameter##name##Node::GetLastMessage(slicer_type & message) const \
+ {									\
+   (reinterpret_cast<vtkMRMLROS2Parameter##name##Internals *>(mInternals))->GetLastMessage(message); \
+ }									\
+									\
+ vtkVariant vtkMRMLROS2Parameter##name##Node::GetLastMessageVariant(void) \
+ {									\
+   return (reinterpret_cast<vtkMRMLROS2Parameter##name##Internals *>(mInternals))->GetLastMessageVariant(); \
+ }
+
+#endif // __vtkMRMLROS2ParameterNativeMacros_h

--- a/MRML/vtkMRMLROS2ParameterNativeNode.cxx
+++ b/MRML/vtkMRMLROS2ParameterNativeNode.cxx
@@ -1,0 +1,7 @@
+#include <vtkROS2ToSlicer.h>
+
+#include <vtkMRMLROS2ParameterNativeNode.h>
+#include <vtkMRMLROS2ParameterNativeInternals.h>
+
+VTK_MRML_ROS_PARAMETER_NATIVE_CXX(std_msgs::msg::String, std::string, String);
+VTK_MRML_ROS_PARAMETER_NATIVE_CXX(std_msgs::msg::Bool, bool, Bool);

--- a/MRML/vtkMRMLROS2ParameterNativeNode.h
+++ b/MRML/vtkMRMLROS2ParameterNativeNode.h
@@ -1,0 +1,10 @@
+#ifndef __vtkMRMLROS2ParameterNativeNode_h
+#define __vtkMRMLROS2ParameterNativeNode_h
+
+#include <vtkMRMLROS2ParameterNode.h>
+#include <vtkMRMLROS2ParameterNativeMacros.h>
+
+VTK_MRML_ROS_PARAMETER_NATIVE_H(std::string, String);
+VTK_MRML_ROS_PARAMETER_NATIVE_H(bool, Bool);
+
+#endif // __vtkMRMLROS2ParameterNativeNode_h

--- a/MRML/vtkMRMLROS2ParameterNode.cxx
+++ b/MRML/vtkMRMLROS2ParameterNode.cxx
@@ -1,0 +1,84 @@
+
+#include <vtkMRMLROS2ParameterNode.h>
+
+#include <vtkMRMLROS2ParameterInternals.h>
+
+void vtkMRMLROS2ParameterNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+  // Custom prints
+  os << indent << "Topic: " << mTopic << "\n";
+  os << indent << "ROS type: " << mInternals->GetROSType() << "\n";
+  os << indent << "Slicer type: " << mInternals->GetSlicerType() << "\n"; // This is scrambled
+  os << indent << "Number of messages: " << mNumberOfMessages << "\n";
+  os << indent << "Last message:" << mInternals->GetLastMessageYAML() << "\n";
+}
+
+bool vtkMRMLROS2ParameterNode::AddToROS2Node(const char * nodeId,
+					      const std::string & topic)
+{
+  mTopic = topic;
+  mMRMLNodeName = "ros2:sub:" + topic;
+  this->SetName(mMRMLNodeName.c_str());
+  vtkMRMLScene * scene = this->GetScene();
+  if (!this->GetScene()) {
+    vtkWarningMacro(<< "AddToROS2Node, subscriber MRML node for topic \"" << topic << "\" needs to be added to the scene first");
+    return false;
+  }
+  std::string errorMessage;
+  if (!mInternals->AddToROS2Node(scene, nodeId, topic, errorMessage)) {
+    vtkErrorMacro(<< "AddToROS2Node, " << errorMessage);
+    return false;
+  }
+  return true;
+}
+
+bool vtkMRMLROS2ParameterNode::IsAddedToROS2Node(void) const
+{
+  return mInternals->IsAddedToROS2Node();
+}
+
+const char * vtkMRMLROS2ParameterNode::GetROSType(void) const
+{
+  return mInternals->GetROSType();
+}
+
+const char * vtkMRMLROS2ParameterNode::GetSlicerType(void) const
+{
+  return mInternals->GetSlicerType();
+}
+
+std::string vtkMRMLROS2ParameterNode::GetLastMessageYAML(void) const
+{
+  return mInternals->GetLastMessageYAML();
+}
+
+void vtkMRMLROS2ParameterNode::WriteXML(std::ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent); // This will take care of referenced nodes
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLStdStringMacro(topicName, Topic);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+void vtkMRMLROS2ParameterNode::ReadXMLAttributes(const char** atts)
+{
+  int wasModifying = this->StartModify();
+  Superclass::ReadXMLAttributes(atts); // This will take care of referenced nodes
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLStdStringMacro(topicName, Topic);
+  vtkMRMLReadXMLEndMacro();
+  this->EndModify(wasModifying);
+}
+
+void vtkMRMLROS2ParameterNode::UpdateScene(vtkMRMLScene *scene)
+{
+  Superclass::UpdateScene(scene);
+  int nbNodeRefs = this->GetNumberOfNodeReferences("node");
+  if (nbNodeRefs != 1) {
+    vtkErrorMacro(<< "No ROS2 node reference defined for subscriber \"" << GetName() << "\"");
+  } else {
+    this->AddToROS2Node(this->GetNthNodeReference("node", 0)->GetID(),
+			mTopic);
+  }
+}

--- a/MRML/vtkMRMLROS2ParameterNode.h
+++ b/MRML/vtkMRMLROS2ParameterNode.h
@@ -1,0 +1,77 @@
+#ifndef __vtkMRMLROS2ParameterNode_h
+#define __vtkMRMLROS2ParameterNode_h
+
+// MRML includes
+#include <vtkMRMLNode.h>
+
+#include <vtkSlicerROS2ModuleMRMLExport.h>
+
+// forward declaration for internals
+class vtkMRMLROS2ParameterInternals;
+
+class VTK_SLICER_ROS2_MODULE_MRML_EXPORT vtkMRMLROS2ParameterNode: public vtkMRMLNode
+{
+
+  // friend declarations
+  friend class vtkMRMLROS2ParameterInternals;
+
+  template <typename _ros_type, typename _slicer_type>
+    friend class vtkMRMLROS2ParameterTemplatedInternals;
+
+ public:
+  vtkTypeMacro(vtkMRMLROS2ParameterNode, vtkMRMLNode);
+
+  bool AddToROS2Node(const char * nodeId,
+		     const std::string & topic);
+
+  bool IsAddedToROS2Node(void) const;
+
+  const std::string & GetTopic(void) const {
+    return mTopic;
+  }
+
+  const char * GetROSType(void) const;
+
+  const char * GetSlicerType(void) const;
+
+  size_t GetNumberOfMessages(void) const {
+    return mNumberOfMessages;
+  }
+
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /**
+   * Get the latest ROS message in YAML format
+   */
+  std::string GetLastMessageYAML(void) const;
+
+  /**
+   * Get the latest message as a vtkVariant.  This method will use the
+   * latest ROS message received and convert it to the internal
+   * Slicer/VTK type if needed.  The result of the conversion is
+   * cached so future calls to GetLastMessage don't require converting
+   * again
+   */
+  virtual vtkVariant GetLastMessageVariant(void) = 0;
+
+  // Save and load
+  virtual void ReadXMLAttributes(const char** atts) override;
+  virtual void WriteXML(std::ostream& of, int indent) override;
+  void UpdateScene(vtkMRMLScene *scene) override;
+
+ protected:
+  vtkMRMLROS2ParameterNode() = default;
+  ~vtkMRMLROS2ParameterNode() = default;
+
+  vtkMRMLROS2ParameterInternals * mInternals = nullptr;
+  std::string mTopic = "undefined";
+  std::string mMRMLNodeName = "ros2:sub:undefined";
+  size_t mNumberOfMessages = 0;
+
+  // For ReadXMLAttributes
+  inline void SetTopic(const std::string & topic) {
+    mTopic = topic;
+  }
+};
+
+#endif // __vtkMRMLROS2ParameterNode_h


### PR DESCRIPTION
@adeguet1 This is a working implementation of a Parameter Node 
It was made using Subscriber code as template and making as little modifications as possible.

There is a lot of redundant code [I dont think ParameterNode needs a topic argument and so on]

I am able to get every updated parameter's **datatype, name and value.**

I believe there isn't a need to have templated classes for the Parameter Node. 
Since a lot of this code will be removed, I'm requesting review on this PR before it is added to the devel branch