### PR TITLE
Added conversion function for vtkUInt8Array to sensor_msgs/Image. Set…

### DIFF
--- a/Logic/vtkSlicerROS2Logic.cxx
+++ b/Logic/vtkSlicerROS2Logic.cxx
@@ -122,7 +122,7 @@ void vtkSlicerROS2Logic::RegisterNodes(void)
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherPoseStampedNode>::New());
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherWrenchStampedNode>::New());
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherPoseArrayNode>::New());
-  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherImageNode>::New());
+  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherUInt8ImageNode>::New());
 #if USE_CISST_MSGS
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherCartesianImpedanceGainsNode>::New());
 #endif

--- a/Logic/vtkSlicerROS2Logic.cxx
+++ b/Logic/vtkSlicerROS2Logic.cxx
@@ -122,6 +122,7 @@ void vtkSlicerROS2Logic::RegisterNodes(void)
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherPoseStampedNode>::New());
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherWrenchStampedNode>::New());
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherPoseArrayNode>::New());
+  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherImageNode>::New());
 #if USE_CISST_MSGS
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLROS2PublisherCartesianImpedanceGainsNode>::New());
 #endif

--- a/MRML/vtkMRMLROS2PublisherDefaultNodes.cxx
+++ b/MRML/vtkMRMLROS2PublisherDefaultNodes.cxx
@@ -16,3 +16,4 @@ VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTable, std_msgs::msg::Float64MultiArray, Doubl
 VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkMatrix4x4, geometry_msgs::msg::PoseStamped, PoseStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkDoubleArray, geometry_msgs::msg::WrenchStamped, WrenchStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTransformCollection, geometry_msgs::msg::PoseArray, PoseArray);
+VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTypeUInt8Array, sensor_msgs::msg::Image, Image);

--- a/MRML/vtkMRMLROS2PublisherDefaultNodes.cxx
+++ b/MRML/vtkMRMLROS2PublisherDefaultNodes.cxx
@@ -16,4 +16,4 @@ VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTable, std_msgs::msg::Float64MultiArray, Doubl
 VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkMatrix4x4, geometry_msgs::msg::PoseStamped, PoseStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkDoubleArray, geometry_msgs::msg::WrenchStamped, WrenchStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTransformCollection, geometry_msgs::msg::PoseArray, PoseArray);
-VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTypeUInt8Array, sensor_msgs::msg::Image, Image);
+VTK_MRML_ROS_PUBLISHER_VTK_CXX(vtkTypeUInt8Array, sensor_msgs::msg::Image, UInt8Image);

--- a/MRML/vtkMRMLROS2PublisherDefaultNodes.h
+++ b/MRML/vtkMRMLROS2PublisherDefaultNodes.h
@@ -12,6 +12,7 @@ VTK_MRML_ROS_PUBLISHER_NATIVE_H(double, Double);
 #include <vtkMatrix4x4.h>
 #include <vtkTransformCollection.h>
 #include <vtkTable.h>
+#include <vtkTypeUInt8Array.h>
 
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkIntArray, IntArray);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkDoubleArray, DoubleArray);
@@ -20,5 +21,6 @@ VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTable, DoubleTable);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkMatrix4x4, PoseStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkDoubleArray, WrenchStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTransformCollection, PoseArray);
+VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTypeUInt8Array, Image);
 
 #endif // __vtkMRMLROS2PublisherDefaultsNodes_h

--- a/MRML/vtkMRMLROS2PublisherDefaultNodes.h
+++ b/MRML/vtkMRMLROS2PublisherDefaultNodes.h
@@ -21,6 +21,6 @@ VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTable, DoubleTable);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkMatrix4x4, PoseStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkDoubleArray, WrenchStamped);
 VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTransformCollection, PoseArray);
-VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTypeUInt8Array, Image);
+VTK_MRML_ROS_PUBLISHER_VTK_H(vtkTypeUInt8Array, UInt8Image);
 
 #endif // __vtkMRMLROS2PublisherDefaultsNodes_h

--- a/MRML/vtkSlicerToROS2.cxx
+++ b/MRML/vtkSlicerToROS2.cxx
@@ -188,6 +188,21 @@ void vtkSlicerToROS2(vtkTransformCollection * input, geometry_msgs::msg::PoseArr
   }
 }
 
+void vtkSlicerToROS2(vtkTypeUInt8Array * input, sensor_msgs::msg::Image & result,
+         const std::shared_ptr<rclcpp::Node> & rosNode)
+{
+  result.header.stamp = rosNode->get_clock()->now();
+  std::vector<uint8_t> picture; 
+  result.width = input->GetNumberOfComponents();
+  result.height = input->GetNumberOfTuples();
+  result.encoding = "mono8"; // grayscale for ultrasound
+  int numberOfValues = input->GetNumberOfValues();
+  for (int i = 0; i < numberOfValues; i ++){
+    picture.push_back(input->GetValue(i));
+  } 
+  result.data = picture;
+}
+
 void vtkMatrix4x4ToQuaternion(vtkMatrix4x4 * input, double quaternion[4])
 {
   double A[3][3];

--- a/MRML/vtkSlicerToROS2.h
+++ b/MRML/vtkSlicerToROS2.h
@@ -1,6 +1,8 @@
 #ifndef __vtkSlicerToROS2_h
 #define __vtkSlicerToROS2_h
 
+#include <cstdint>
+
 // VTK
 #include <vtkMatrix4x4.h>
 #include <vtkSmartPointer.h>
@@ -8,6 +10,7 @@
 #include <vtkIntArray.h>
 #include <vtkTransformCollection.h>
 #include <vtkTable.h>
+#include <vtkTypeUInt8Array.h>
 
 // ROS2
 #include <rclcpp/rclcpp.hpp>
@@ -21,6 +24,7 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 void vtkSlicerToROS2(const std::string & input,  std_msgs::msg::String & result,
 		     const std::shared_ptr<rclcpp::Node> & rosNode);
@@ -45,6 +49,8 @@ void vtkSlicerToROS2(vtkMatrix4x4 * input, geometry_msgs::msg::TransformStamped 
 void vtkSlicerToROS2(vtkDoubleArray * input, geometry_msgs::msg::WrenchStamped & result,
 		     const std::shared_ptr<rclcpp::Node> & rosNode);
 void vtkSlicerToROS2(vtkTransformCollection * input, geometry_msgs::msg::PoseArray & result,
+		     const std::shared_ptr<rclcpp::Node> & rosNode);
+void vtkSlicerToROS2(vtkTypeUInt8Array * input, sensor_msgs::msg::Image & result,
 		     const std::shared_ptr<rclcpp::Node> & rosNode);
 
 // helper function


### PR DESCRIPTION
Added feature request: vtkUInt8Array to sensor_msgs/Image. Tested on ultrasound images with the following python script that assumes you have an US image in the scene called "Image_Reference": 

image = slicer.mrmlScene.GetFirstNodeByName('Image_Reference')
from vtk.util import numpy_support
array = slicer.util.arrayFromVolume(image)
vtkIntArray = numpy_support.numpy_to_vtk(array[0, :, :])
logic = slicer.util.getModuleLogic('ROS2')
node = logic.GetDefaultROS2Node()
publisher = node.CreateAndAddPublisherNode('vtkMRMLROS2PublisherImageNode', '/my_image')
publisher.Publish(vtkIntArray)
